### PR TITLE
Update line.rb

### DIFF
--- a/lib/omniauth/strategies/line.rb
+++ b/lib/omniauth/strategies/line.rb
@@ -35,7 +35,10 @@ module OmniAuth
       rescue ::Errno::ETIMEDOUT
         raise ::Timeout::Error
       end
-
+      
+      def callback_url
+        full_host + script_name + callback_path
+      end
     end
   end
 end


### PR DESCRIPTION
omniauth-google-oauth2 跟 omniauth-line 要求的 omniauth-oauth2 版本不同，導致降 omniauth-oauth2 會讓 google 出錯，而升級至 1.6 會導致 line 出錯

```
Bundler could not find compatible versions for gem "omniauth-oauth2":
  In snapshot (Gemfile.lock):
    omniauth-oauth2 (= 1.7.0)

  In Gemfile:
    omniauth-google-oauth2 (= 0.8.0) was resolved to 0.8.0, which depends on
      omniauth-oauth2 (>= 1.6)

    omniauth-line was resolved to 0.0.3, which depends on
      omniauth-oauth2 (~> 1.3.1)
```

升級至 1.6 會導致 line 出錯，主要的原因就是 omniauth-oauth2 的這個 [commit](https://github.com/omniauth/omniauth-oauth2/commit/26152673224aca5c3e918bcc83075dbb0659717f)，將 callback_url 移除，所以才會一直出現 `redirect_uri_mismatch` 的錯誤

嘗試研究 omniauth-line source code 很久，終於找到簡單的切入點，另外也看到有人也是這樣採用 https://github.com/omniauth/omniauth-oauth2/commit/26152673224aca5c3e918bcc83075dbb0659717f